### PR TITLE
Fix LTspice AC source definition

### DIFF
--- a/fra/rc_circuits_fra.asc
+++ b/fra/rc_circuits_fra.asc
@@ -36,7 +36,7 @@ WINDOW 123 24 124 Left 2
 WINDOW 39 0 0 Left 2
 SYMATTR Value2 AC 1
 SYMATTR InstName V1
-SYMATTR Value SINE()
+SYMATTR Value ""
 SYMBOL e 256 240 R0
 WINDOW 3 16 102 Left 2
 SYMATTR Value Laplace = wn/(s +wn)


### PR DESCRIPTION
Remove unused SINE() source definition for AC analysis compatibility with LTspice 24.x